### PR TITLE
feat: Add recipe book + fix itemID field

### DIFF
--- a/script.js
+++ b/script.js
@@ -353,27 +353,24 @@ function saveItem(e) {
     }
 
     if (editingItemId) {
-        // Update existing item
+        // Update existing item - original logic, does not add itemId
         const itemRef = database.ref(`${currentCategory}/${editingItemId}`);
-        itemRef.once('value', (snapshot) => {
-            if (snapshot.exists()) {
-                itemRef.update(itemData)
-                    .then(() => {
-                        console.log('Item updated successfully');
-                        hideModal();
-                    })
-                    .catch(error => {
-                        console.error('Error updating item:', error);
-                        alert('שגיאה בעדכון הפריט. אנא נסה שוב.');
-                    });
-            } else {
-                alert('הפריט לא נמצא במערכת. ייתכן שנמחק.');
+        itemRef.update(itemData)
+            .then(() => {
+                console.log('Item updated successfully');
                 hideModal();
-            }
-        });
+            })
+            .catch(error => {
+                console.error('Error updating item:', error);
+                alert('שגיאה בעדכון הפריט. אנא נסה שוב.');
+            });
     } else {
         // Add new item
-        database.ref(selectedCategory).push(itemData)
+        const newItemRef = database.ref(selectedCategory).push();
+        const itemId = newItemRef.key;
+        itemData.itemId = itemId; // Add the generated key as itemId
+
+        newItemRef.set(itemData)
             .then(() => {
                 console.log('Item added successfully');
                 hideModal();


### PR DESCRIPTION
This commit refines the previous implementation to add an `itemId` field only to newly created items in the `books`, `food`, and `items` categories.

Key changes:
- The `saveItem` function in `script.js` has been updated.
  - When creating a new item, the code now gets the unique key from Firebase, adds it to the item data as `itemId`, and then saves the complete object.
  - The update logic for existing items has been reverted to its original state and will no longer add or modify the `itemId` field, as per the user's request.
- The display of the `itemId` field in the UI has been removed. The field will now only exist in the database.

This change correctly implements the user's final requirements for the `itemId` feature.